### PR TITLE
Get _start_state on DocOpen, regardless of settings

### DIFF
--- a/SlackitRevit/EventsApplication.cs
+++ b/SlackitRevit/EventsApplication.cs
@@ -75,6 +75,12 @@ namespace SlackitRevit
             Variables.logVersionName = app.VersionName;
             Variables.logVersionNumber = app.VersionNumber;
             #endregion
+            
+            #region Tracking: Start Logging Pinned Elements
+            IEnumerable<Element> a = TrackChanges.Command.GetTrackedElements(doc);
+            _start_state = TrackChanges.Command.GetSnapshot(a);
+            #endregion
+
 
             #region Settings: Load settings if they exist (Extensible Storage)
             ParameterCommands.Load(doc);
@@ -219,12 +225,6 @@ namespace SlackitRevit
                         msgts_model.Add(resp.ts);
                     }
                 }
-                #endregion
-
-                #region Tracking: Start Logging Pinned Elements
-                IEnumerable<Element> a = TrackChanges.Command.GetTrackedElements(doc);
-                _start_state = TrackChanges.Command.GetSnapshot(a);
-
                 #endregion
 
                 #region Post: Tracking-Pinned Element-Started


### PR DESCRIPTION
This should resolve #13, where someone opens a project and doesn't have pinned element tracking enabled, but then enables it and syncs. Since it previously didn't grab _start_state, the ReportChanges method would then fail due to a null _start_state.

I explored options of getting the _start_state when someone changes their SlackIt settings, but this would also have to account for receiving new changes via syncing the model. You'd also have to track the before and after save settings to see if it is enabled, which would add a layer of complexity. _start_state is already being updated every time you sync, so also doing so on document open is more in line with that pattern.